### PR TITLE
Allow to specify an alternative prefix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! extern crate synstructure;
 //! #[macro_use]
 //! extern crate quote;
-//! use synstructure::{each_field, BindStyle};
+//! use synstructure::{each_field, BindStyle, Options};
 //!
 //! type TokenStream = String; // XXX: Dummy to not depend on rustc_macro
 //!
@@ -20,7 +20,7 @@
 //!     let source = input.to_string();
 //!     let mut ast = syn::parse_macro_input(&source).unwrap();
 //!
-//!     let match_body = each_field(&mut ast, BindStyle::Ref, |bi| quote! {
+//!     let match_body = each_field(&mut ast, &Options::new(BindStyle::Ref), |bi| quote! {
 //!         sum += #bi as i64;
 //!     });
 //!
@@ -68,6 +68,40 @@ pub enum BindStyle {
     RefMut,
 }
 
+/// Binding options to use when generating a pattern.
+pub struct Options {
+    bind_style: BindStyle,
+    prefix: String,
+}
+
+impl Options {
+    /// Use the given style and the prefix "__binding" when generating a pattern.
+    pub fn new(bind_style: BindStyle) -> Options {
+        Options {
+            bind_style: bind_style,
+            prefix: "__binding".into(),
+        }
+    }
+
+    /// Use the given style and prefix when generating a pattern.
+    pub fn with_prefix(bind_style: BindStyle, prefix: String) -> Options {
+        Options {
+            bind_style: bind_style,
+            prefix: prefix,
+        }
+    }
+
+    /// The style to use to generate patterns.
+    pub fn bind_style(&self) -> BindStyle {
+        self.bind_style
+    }
+
+    /// The prefix to use to generate patterns.
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+}
+
 /// Information about a specific binding. This contains both an `Ident`
 /// reference to the given field, and the syn `&'a Field` descriptor for that
 /// field.
@@ -100,7 +134,7 @@ impl<'a> ToTokens for BindingInfo<'a> {
 /// ```
 /// extern crate syn;
 /// extern crate synstructure;
-/// use synstructure::{match_pattern, BindStyle};
+/// use synstructure::{match_pattern, BindStyle, Options};
 ///
 /// fn main() {
 ///     let mut ast = syn::parse_macro_input("struct A { a: i32, b: i32 }").unwrap();
@@ -108,7 +142,7 @@ impl<'a> ToTokens for BindingInfo<'a> {
 ///         vd
 ///     } else { unreachable!() };
 ///
-///     let (tokens, bindings) = match_pattern(&ast.ident, vd, BindStyle::Ref);
+///     let (tokens, bindings) = match_pattern(&ast.ident, vd, &Options::new(BindStyle::Ref));
 ///     assert_eq!(&tokens.to_string(),
 ///                "A { a : ref  __binding_0 ,  b : ref  __binding_1 ,  } ");
 ///     assert_eq!(bindings.len(), 2);
@@ -118,12 +152,12 @@ impl<'a> ToTokens for BindingInfo<'a> {
 /// ```
 pub fn match_pattern<'a, N: ToTokens>(name: &N,
                                       vd: &'a mut VariantData,
-                                      bind: BindStyle)
+                                      options: &Options)
                                       -> (Tokens, Vec<BindingInfo<'a>>) {
     let mut t = Tokens::new();
     let mut matches = Vec::new();
 
-    let prefix = match bind {
+    let prefix = match options.bind_style() {
         BindStyle::Move => Tokens::new(),
         BindStyle::MoveMut => quote!(mut),
         BindStyle::Ref => quote!(ref),
@@ -136,7 +170,7 @@ pub fn match_pattern<'a, N: ToTokens>(name: &N,
         VariantData::Tuple(ref mut fields) => {
             t.append("(");
             for (i, field) in fields.iter_mut().enumerate() {
-                let ident: Ident = format!("__binding_{}", i).into();
+                let ident: Ident = format!("{}_{}", options.prefix(), i).into();
                 quote!(#prefix #ident ,).to_tokens(&mut t);
                 matches.push(BindingInfo {
                     ident: ident,
@@ -148,7 +182,7 @@ pub fn match_pattern<'a, N: ToTokens>(name: &N,
         VariantData::Struct(ref mut fields) => {
             t.append("{");
             for (i, field) in fields.iter_mut().enumerate() {
-                let ident: Ident = format!("__binding_{}", i).into();
+                let ident: Ident = format!("{}_{}", options.prefix(), i).into();
                 {
                     let field_name = field.ident.as_ref().unwrap();
                     quote!(#field_name : #prefix #ident ,).to_tokens(&mut t);
@@ -182,12 +216,12 @@ pub fn match_pattern<'a, N: ToTokens>(name: &N,
 /// extern crate synstructure;
 /// #[macro_use]
 /// extern crate quote;
-/// use synstructure::{match_substructs, BindStyle};
+/// use synstructure::{match_substructs, BindStyle, Options};
 ///
 /// fn main() {
 ///     let mut ast = syn::parse_macro_input("struct A { a: i32, b: i32 }").unwrap();
 ///
-///     let tokens = match_substructs(&mut ast, BindStyle::Ref, |bindings| {
+///     let tokens = match_substructs(&mut ast, &Options::new(BindStyle::Ref), |bindings| {
 ///         assert_eq!(bindings.len(), 2);
 ///         assert_eq!(bindings[0].ident.as_ref(), "__binding_0");
 ///         assert_eq!(bindings[1].ident.as_ref(), "__binding_1");
@@ -198,7 +232,7 @@ pub fn match_pattern<'a, N: ToTokens>(name: &N,
 ///     assert_eq!(&tokens.to_string(), e);
 /// }
 /// ```
-pub fn match_substructs<F, T: ToTokens>(input: &mut MacroInput, bind: BindStyle, func: F) -> Tokens
+pub fn match_substructs<F, T: ToTokens>(input: &mut MacroInput, options: &Options, func: F) -> Tokens
     where F: Fn(Vec<BindingInfo>) -> T
 {
     let ident = &input.ident;
@@ -208,11 +242,11 @@ pub fn match_substructs<F, T: ToTokens>(input: &mut MacroInput, bind: BindStyle,
             variants.iter_mut()
                 .map(|variant| {
                     let variant_ident = &variant.ident;
-                    match_pattern(&quote!(#ident :: #variant_ident), &mut variant.data, bind)
+                    match_pattern(&quote!(#ident :: #variant_ident), &mut variant.data, &options)
                 })
                 .collect()
         }
-        Body::Struct(ref mut vd) => vec![match_pattern(&ident, vd, bind)],
+        Body::Struct(ref mut vd) => vec![match_pattern(&ident, vd, &options)],
     };
 
     // Now that we have the patterns, generate the actual branches of the match
@@ -241,12 +275,12 @@ pub fn match_substructs<F, T: ToTokens>(input: &mut MacroInput, bind: BindStyle,
 /// extern crate synstructure;
 /// #[macro_use]
 /// extern crate quote;
-/// use synstructure::{each_field, BindStyle};
+/// use synstructure::{each_field, BindStyle, Options};
 ///
 /// fn main() {
 ///     let mut ast = syn::parse_macro_input("struct A { a: i32, b: i32 }").unwrap();
 ///
-///     let tokens = each_field(&mut ast, BindStyle::Ref, |bi| quote! {
+///     let tokens = each_field(&mut ast, &Options::new(BindStyle::Ref), |bi| quote! {
 ///         println!("Saw: {:?}", #bi);
 ///     });
 ///     let e = concat!("A { a : ref  __binding_0 ,  b : ref  __binding_1 ,  }  ",
@@ -257,10 +291,10 @@ pub fn match_substructs<F, T: ToTokens>(input: &mut MacroInput, bind: BindStyle,
 ///     assert_eq!(&tokens.to_string(), e);
 /// }
 /// ```
-pub fn each_field<F, T: ToTokens>(input: &mut MacroInput, bind: BindStyle, func: F) -> Tokens
+pub fn each_field<F, T: ToTokens>(input: &mut MacroInput, options: &Options, func: F) -> Tokens
     where F: Fn(BindingInfo) -> T
 {
-    match_substructs(input, bind, |infos| {
+    match_substructs(input, options, |infos| {
         let mut t = Tokens::new();
         for info in infos {
             t.append("{");

--- a/tests/alt_prefix.rs
+++ b/tests/alt_prefix.rs
@@ -1,0 +1,21 @@
+extern crate syn;
+extern crate synstructure;
+#[macro_use]
+extern crate quote;
+use synstructure::{match_substructs, BindStyle, Options};
+
+#[test]
+fn alt_prefix() {
+    let mut ast = syn::parse_macro_input("struct A { a: i32, b: i32 }").unwrap();
+
+    let opts = Options::with_prefix(BindStyle::Ref, "__foo".into());
+    let tokens = match_substructs(&mut ast, &opts, |bindings| {
+        assert_eq!(bindings.len(), 2);
+        assert_eq!(bindings[0].ident.as_ref(), "__foo_0");
+        assert_eq!(bindings[1].ident.as_ref(), "__foo_1");
+        quote!("some_random_string")
+    });
+    let e = concat!("A { a : ref  __foo_0 ,  b : ref  __foo_1 ,  }",
+                    "  => { \"some_random_string\"  }  ");
+    assert_eq!(&tokens.to_string(), e);
+}


### PR DESCRIPTION
This is just a proposition, feel free to close it if you don't like it!

---

While the solution you proposed on [`syn`'s repo](https://github.com/dtolnay/syn/issues/27#issuecomment-252493037) to have nested `match`es would work, I think it's quite inelegant. Espicially considering that `derive(Ord)` currently uses *n+2* nested `match`es for a structure with *n* fields.
This PR changes the interface to take an `options: &Options` instead of just a `bind: BindStyle`. An `Options` is just the binding style plus a prefix.
While calling the functions needs slightly more typing that before, I think it does not clutter up the interface too much.


(This would also allow adding other stuffs later backward-compatibly, although I admit I don't know what one would need more yet, but the crate is not even 3 hours old so you never know :smile:.)