### PR TITLE
Specific bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ syn = { version = "0.13", features = ["visit", "extra-traits"] }
 proc-macro2 = "0.3"
 quote = "0.5"
 unicode-xid = "0.1"
+indexmap = "1.0.0"
 
 [dev-dependencies]
 # Used in the documentation as an example trait crate provider. Unfortunately,


### PR DESCRIPTION
Fixes #10 

This is a complete non-breaking change but it does put into question whether we should deprecate some of the existing methods. i.e., `unbound_impl` and `unsafe_unbound_impl` since the same behavior can be achieved by calling `.bounds(BoundsToAdd::None)` followed by either `bound_impl`/`unsafe_bound_impl` or `gen_impl`. Maybe `bound_impl` can also be deprecated?

