### PR TITLE
update TokenStream::empty() to TokenStream::new() per deprecation warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ impl<'a> VariantInfo<'a> {
     /// # }
     /// ```
     pub fn pat(&self) -> TokenStream {
-        let mut t = TokenStream::empty();
+        let mut t = TokenStream::new();
         if let Some(prefix) = self.prefix {
             prefix.to_tokens(&mut t);
             quote!(::).to_tokens(&mut t);
@@ -621,7 +621,7 @@ impl<'a> VariantInfo<'a> {
         F: FnMut(&Field, usize) -> T,
         T: ToTokens,
     {
-        let mut t = TokenStream::empty();
+        let mut t = TokenStream::new();
         if let Some(prefix) = self.prefix {
             quote!(#prefix ::).to_tokens(&mut t);
         }
@@ -690,7 +690,7 @@ impl<'a> VariantInfo<'a> {
         R: ToTokens,
     {
         let pat = self.pat();
-        let mut body = TokenStream::empty();
+        let mut body = TokenStream::new();
         for binding in &self.bindings {
             token::Brace::default().surround(&mut body, |body| {
                 f(binding).to_tokens(body);
@@ -1078,7 +1078,7 @@ impl<'a> Structure<'a> {
         F: FnMut(&BindingInfo) -> R,
         R: ToTokens,
     {
-        let mut t = TokenStream::empty();
+        let mut t = TokenStream::new();
         for variant in &self.variants {
             variant.each(&mut f).to_tokens(&mut t);
         }
@@ -1132,7 +1132,7 @@ impl<'a> Structure<'a> {
         I: ToTokens,
         R: ToTokens,
     {
-        let mut t = TokenStream::empty();
+        let mut t = TokenStream::new();
         for variant in &self.variants {
             variant.fold(&init, &mut f).to_tokens(&mut t);
         }
@@ -1186,7 +1186,7 @@ impl<'a> Structure<'a> {
         F: FnMut(&VariantInfo) -> R,
         R: ToTokens,
     {
-        let mut t = TokenStream::empty();
+        let mut t = TokenStream::new();
         for variant in &self.variants {
             let pat = variant.pat();
             let body = f(variant);


### PR DESCRIPTION
Compiling synstructure generates warnings that proc_macro2::TokenStream::empty is deprecated, f.e.:

>warning: use of deprecated item 'proc_macro2::TokenStream::empty': please use TokenStream::new
>   --> src/lib.rs:544:21
>    |
>544 |         let mut t = TokenStream::empty();
>    |                     ^^^^^^^^^^^^^^^^^^
>    |

(Found when I vendored rkv > failure > failure_derive > synstructure into mozilla-central in [bug 1445451](https://bugzilla.mozilla.org/show_bug.cgi?id=1445451), which triggered compiler warning regression [bug 1482810](https://bugzilla.mozilla.org/show_bug.cgi?id=1482810).)
