### PR TITLE
Fix typo ('avaliable', misplaced 'i')

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -172,7 +172,7 @@ got:
 /// # Note
 ///
 /// This feature is implemented behind the `simple-derive` feature, and is only
-/// avaliable when that feature is enabled.
+/// available when that feature is enabled.
 ///
 /// # Example
 ///


### PR DESCRIPTION
Just fixing a trivial typo in a code-comment.