### PR TITLE
add #[doc(hidden)] attribute to dummy const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1298,6 +1298,7 @@ impl<'a> Structure<'a> {
     ///     }).to_string(),
     ///     quote!{
     ///         #[allow(non_upper_case_globals)]
+    ///         #[doc(hidden)]
     ///         const _DERIVE_krate_Trait_FOR_A: () = {
     ///             extern crate krate;
     ///             impl<T, U> krate::Trait for A<T, U>
@@ -1546,6 +1547,7 @@ impl<'a> Structure<'a> {
     ///     ).to_string(),
     ///     quote!{
     ///         #[allow(non_upper_case_globals)]
+    ///         #[doc(hidden)]
     ///         const _DERIVE_krate_Trait_X_FOR_A: () = {
     ///             extern crate krate;
     ///             impl<T, U, X: krate::AnotherTrait> krate::Trait<X> for A<T, U>
@@ -1686,6 +1688,7 @@ impl<'a> Structure<'a> {
     ///     }).to_string(),
     ///     quote!{
     ///         #[allow(non_upper_case_globals)]
+    ///         #[doc(hidden)]
     ///         const _DERIVE_krate_Trait_FOR_A: () = {
     ///             extern crate krate;
     ///             impl<T, U> krate::Trait for A<T, U>
@@ -1760,6 +1763,7 @@ impl<'a> Structure<'a> {
     ///     }).to_string(),
     ///     quote!{
     ///         #[allow(non_upper_case_globals)]
+    ///         #[doc(hidden)]
     ///         const _DERIVE_krate_Trait_FOR_A: () = {
     ///             extern crate krate;
     ///             unsafe impl<T, U> krate::Trait for A<T, U>
@@ -1827,6 +1831,7 @@ impl<'a> Structure<'a> {
     ///     }).to_string(),
     ///     quote!{
     ///         #[allow(non_upper_case_globals)]
+    ///         #[doc(hidden)]
     ///         const _DERIVE_krate_Trait_FOR_A: () = {
     ///             extern crate krate;
     ///             impl<T, U> krate::Trait for A<T, U> {
@@ -1891,6 +1896,7 @@ impl<'a> Structure<'a> {
     ///     }).to_string(),
     ///     quote!{
     ///         #[allow(non_upper_case_globals)]
+    ///         #[doc(hidden)]
     ///         const _DERIVE_krate_Trait_FOR_A: () = {
     ///             extern crate krate;
     ///             unsafe impl<T, U> krate::Trait for A<T, U> {
@@ -1951,6 +1957,7 @@ impl<'a> Structure<'a> {
 
         quote! {
             #[allow(non_upper_case_globals)]
+            #[doc(hidden)]
             const #dummy_const: () = {
                 #extern_crate
                 #safety impl #impl_generics #bound for #name #ty_generics #where_clause {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -226,6 +226,7 @@ got:
 ///         }
 ///         expands to {
 ///             #[allow(non_upper_case_globals)]
+///             #[doc(hidden)]
 ///             const _DERIVE_synstructure_test_traits_Interest_FOR_A: () = {
 ///                 extern crate synstructure_test_traits;
 ///                 impl<T> synstructure_test_traits::Interest for A<T>

--- a/test_suite/test_macros/macros.rs
+++ b/test_suite/test_macros/macros.rs
@@ -31,6 +31,7 @@ fn test() {
         }
         expands to {
             #[allow(non_upper_case_globals)]
+            #[doc(hidden)]
             const _DERIVE_synstructure_test_traits_Interest_FOR_A: () = {
                 extern crate synstructure_test_traits;
                 impl synstructure_test_traits::Interest for A {


### PR DESCRIPTION
This allows users of `--document-private-items` to strip the dummy const from documentation via `--strip-hidden`.

cc rust-lang/rust#60150