### PR TITLE
Work around `overflow evaluating the requirement` in Nightly rustdoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synstructure"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Nika Layzell <nika@thelayzells.com>"]
 
 description = "Helper methods and macros for custom derives"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,9 @@
 //! For more example usage, consider investigating the `abomonation_derive` crate,
 //! which makes use of this crate, and is fairly simple.
 
+// https://github.com/rust-lang/rust/issues/62132
+#![recursion_limit="128"]
+
 extern crate proc_macro;
 extern crate proc_macro2;
 #[macro_use]

--- a/test_traits/Cargo.toml
+++ b/test_traits/Cargo.toml
@@ -8,3 +8,7 @@ authors = ["Nika Layzell <nika@thelayzells.com>"]
 
 [lib]
 path = "lib.rs"
+
+[dependencies]
+# To trigger https://github.com/rust-lang/rust/issues/62132
+syn = { version = "0.15", features = ["full"] }


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/62132 and https://github.com/rust-lang/rust/issues/62059.

The fix in rustdoc is at the “investigating the feasibility” stage, and this is preventing Servo from upgrading its Rust toolchain.