### PR TITLE
Update unicode-xid to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 syn = { version = "1", features = ["visit", "extra-traits"] }
 proc-macro2 = "1"
 quote = "1"
-unicode-xid = "0.1"
+unicode-xid = "0.2"
 
 [dev-dependencies]
 # Used in the documentation as an example trait crate provider. Unfortunately,


### PR DESCRIPTION
This attempts to update `unicode-xid` to 0.2, closing #33. 

I have tested it on my machine and it compiled cleanly.