### PR TITLE
Improve macro hygiene of some decl macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -95,13 +95,17 @@ macro_rules! decl_derive {
             i: $crate::macros::TokenStream
         ) -> $crate::macros::TokenStream {
             match $crate::macros::parse::<$crate::macros::DeriveInput>(i) {
-                Ok(p) => {
+                ::core::result::Result::Ok(p) => {
                     match $crate::Structure::try_new(&p) {
-                        Ok(s) => $crate::MacroResult::into_stream($inner(s)),
-                        Err(e) => e.to_compile_error().into(),
+                        ::core::result::Result::Ok(s) => $crate::MacroResult::into_stream($inner(s)),
+                        ::core::result::Result::Err(e) => {
+                            ::core::convert::Into::into(e.to_compile_error())
+                        }
                     }
                 }
-                Err(e) => e.to_compile_error().into(),
+                ::core::result::Result::Err(e) => {
+                    ::core::convert::Into::into(e.to_compile_error())
+                }
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -153,11 +153,19 @@ macro_rules! decl_attribute {
             i: $crate::macros::TokenStream,
         ) -> $crate::macros::TokenStream {
             match $crate::macros::parse::<$crate::macros::DeriveInput>(i) {
-                Ok(p) => match $crate::Structure::try_new(&p) {
-                    Ok(s) => $crate::MacroResult::into_stream($inner(attr.into(), s)),
-                    Err(e) => e.to_compile_error().into(),
+                ::core::result::Result::Ok(p) => match $crate::Structure::try_new(&p) {
+                    ::core::result::Result::Ok(s) => {
+                        $crate::MacroResult::into_stream(
+                            $inner(::core::convert::Into::into(attr), s)
+                        )
+                    }
+                    ::core::result::Result::Err(e) => {
+                        ::core::convert::Into::into(e.to_compile_error())
+                    }
                 },
-                Err(e) => e.to_compile_error().into(),
+                ::core::result::Result::Err(e) => {
+                    ::core::convert::Into::into(e.to_compile_error())
+                }
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -209,28 +209,31 @@ macro_rules! test_derive {
 
     ($name:path { $($i:tt)* } expands to { $($o:tt)* } no_build) => {
         {
-            let i = stringify!( $($i)* );
+            let i = ::core::stringify!( $($i)* );
             let parsed = $crate::macros::parse_str::<$crate::macros::DeriveInput>(i)
-                .expect(concat!(
+                .expect(::core::concat!(
                     "Failed to parse input to `#[derive(",
-                    stringify!($name),
+                    ::core::stringify!($name),
                     ")]`",
                 ));
 
             let raw_res = $name($crate::Structure::new(&parsed));
             let res = $crate::MacroResult::into_result(raw_res)
-                .expect(concat!(
+                .expect(::core::concat!(
                     "Procedural macro failed for `#[derive(",
-                    stringify!($name),
+                    ::core::stringify!($name),
                     ")]`",
                 ));
 
-            let expected = stringify!( $($o)* )
+            let expected = ::core::stringify!( $($o)* )
                 .parse::<$crate::macros::TokenStream2>()
                 .expect("output should be a valid TokenStream");
-            let mut expected_toks = $crate::macros::TokenStream2::from(expected);
-            if res.to_string() != expected_toks.to_string() {
-                panic!("\
+            let mut expected_toks = <$crate::macros::TokenStream2
+                as ::core::convert::From<$crate::macros::TokenStream2>>::from(expected);
+            ::core::assert_eq!(
+                <$crate::macros::TokenStream2 as ::std::string::ToString>::to_string(&res),
+                <$crate::macros::TokenStream2 as ::std::string::ToString>::to_string(&expected_toks),
+                "\
 test_derive failed:
 expected:
 ```
@@ -241,10 +244,9 @@ got:
 ```
 {}
 ```\n",
-                    $crate::unpretty_print(&expected_toks),
-                    $crate::unpretty_print(&res),
-                );
-            }
+                $crate::unpretty_print(&expected_toks),
+                $crate::unpretty_print(&res),
+            );
         }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -242,10 +242,10 @@ macro_rules! test_derive {
                 .expect("output should be a valid TokenStream");
             let mut expected_toks = <$crate::macros::TokenStream2
                 as ::core::convert::From<$crate::macros::TokenStream2>>::from(expected);
-            ::core::assert_eq!(
-                <$crate::macros::TokenStream2 as ::std::string::ToString>::to_string(&res),
-                <$crate::macros::TokenStream2 as ::std::string::ToString>::to_string(&expected_toks),
-                "\
+            if <$crate::macros::TokenStream2 as ::std::string::ToString>::to_string(&res)
+                != <$crate::macros::TokenStream2 as ::std::string::ToString>::to_string(&expected_toks)
+            {
+                panic!("\
 test_derive failed:
 expected:
 ```
@@ -256,9 +256,10 @@ got:
 ```
 {}
 ```\n",
-                $crate::unpretty_print(&expected_toks),
-                $crate::unpretty_print(&res),
-            );
+                    $crate::unpretty_print(&expected_toks),
+                    $crate::unpretty_print(&res),
+                );
+            }
         }
     };
 }


### PR DESCRIPTION
I was running into some problems with this crate and also a `clippy` warning was showing up with code expanded by the `test_derive` decl macro of this crate so I fixed the `clippy` warning as well as improved the macro hygiene of the declarative macros in that file.
It might be a good idea to later add `#![no_implicit_prelude]` tests for those to guard against macro hygiene problems in the future. :)

Hope the changes are appreciated. :)

There is one test failing but it also fails on the `master` branch so I doubt it has anything to do with this PR.

The `clippy` warning I received in my dependency was the following:

```
warning: only a `panic!` in `if`-then statement
   --> crates/storage/derive/src/tests/storage_layout.rs:72:5
    |
72  | /     synstructure::test_derive! {
73  | |         storage_layout_derive {
74  | |             struct NamedFieldsStruct {
75  | |                 a: bool,
...   |
103 | |         }
104 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#if_then_panic
    = note: this warning originates in the macro `$crate::test_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Source of the `clippy` issue is here: https://github.com/mystor/synstructure/blob/26b84b4dd4e29eef7436b94ba656cd0765a6c4a0/src/macros.rs#L232-L246