### PR TITLE
Update to syn 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ quote = { version = "1", default-features = false }
 unicode-xid = "0.2"
 
 [dependencies.syn]
-version = "1"
+version = "2"
 default-features = false
 features = ["derive", "parsing", "printing", "clone-impls", "visit", "extra-traits"]
 


### PR DESCRIPTION
The portion of the API you use was unchanged between syn 1 and syn 2. This will allow users to continue using `synstructure` alongside `syn` 2.x