### PR TITLE
test_derive! diffs output on failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = ["proc-macro"]
 proc-macro = ["proc-macro2/proc-macro", "syn/proc-macro", "quote/proc-macro"]
 
 [dependencies]
+dissimilar = "1.0.9"
 proc-macro2 = { version = "1.0.60", default-features = false }
 quote = { version = "1", default-features = false }
 


### PR DESCRIPTION
When its two inputs differ, `test_derive!` diffs its inputs and panics with the diff rather than printing both inputs in full.

Closes #65