### PR TITLE
Set rust-version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "synstructure"
 version = "0.13.2"
 authors = ["Nika Layzell <nika@thelayzells.com>"]
 edition = "2018"
-
+rust-version = "1.56.1"
 description = "Helper methods and macros for custom derives"
 documentation = "https://docs.rs/synstructure"
 repository = "https://github.com/mystor/synstructure"


### PR DESCRIPTION
Now that the MSRV is 1.56+ it should be safe to set rust-version in Cargo.toml.